### PR TITLE
Fix stop speaking in YandexTextToSpeech

### DIFF
--- a/AimyboxCore/Aimybox/Impl/AimyboxConcrete.swift
+++ b/AimyboxCore/Aimybox/Impl/AimyboxConcrete.swift
@@ -97,7 +97,6 @@ internal class AimyboxConcrete<TDialogAPI, TConfig>: Aimybox where TConfig: Aimy
     }
     
     public func speak(speech: [AimyboxSpeech], next action: AimyboxNextAction) {
-        state = .speaking
         nextAction = action
         config.textToSpeech.synthesize(contentsOf: speech)
     }
@@ -227,6 +226,8 @@ extension AimyboxConcrete {
                     standby()
                 }
             }
+        case .speechSequenceStarted:
+            state = .speaking
         default:
             break
         }

--- a/Components/YandexSpeechKit/Sources/YandexSynthesisAPI/YandexSynthesisAPI.swift
+++ b/Components/YandexSpeechKit/Sources/YandexSynthesisAPI/YandexSynthesisAPI.swift
@@ -100,12 +100,25 @@ class YandexSynthesisAPI {
 }
 
 public struct YandexSynthesisConfig {
-    
     var voice: String
     var emotion: String
     var speed: Float
     var format: String
     var sampleRateHertz: Int
+
+    public init(
+        voice: String,
+        emotion: String,
+        speed: Float,
+        format: String,
+        sampleRateHertz: Int
+    ) {
+        self.voice = voice
+        self.emotion = emotion
+        self.speed = speed
+        self.format = format
+        self.sampleRateHertz = sampleRateHertz
+    }
 }
 
 public extension YandexSynthesisConfig {

--- a/Components/YandexSpeechKit/Sources/YandexSynthesisAPI/YandexTextToSpeech.swift
+++ b/Components/YandexSpeechKit/Sources/YandexSynthesisAPI/YandexTextToSpeech.swift
@@ -24,7 +24,7 @@ public class YandexTextToSpeech: AimyboxComponent, TextToSpeech {
     private var synthesisAPI: YandexSynthesisAPI!
     /**
     */
-    internal var audioPlayer: AVAudioPlayer?
+    internal var player: AVPlayer?
     /**
      */
     internal var notificationQueue: OperationQueue
@@ -57,6 +57,7 @@ public class YandexTextToSpeech: AimyboxComponent, TextToSpeech {
     }
     
     public func synthesize(contentsOf speeches: [AimyboxSpeech]) {
+        isCancelled = false
         operationQueue.addOperation { [weak self] in
             self?.prepareAudioEngine { engineIsReady in
                 if engineIsReady {
@@ -70,9 +71,8 @@ public class YandexTextToSpeech: AimyboxComponent, TextToSpeech {
     }
     
     public func stop() {
-        operationQueue.addOperation { [weak self] in
-            self?.audioPlayer?.stop()
-        }
+        isCancelled = true
+        player?.pause()
     }
     
     public func cancelSynthesis() {
@@ -96,7 +96,11 @@ public class YandexTextToSpeech: AimyboxComponent, TextToSpeech {
             synthesize(speech)
         }
 
-        _notify(.success(.speechSequenceCompleted(speeches)))
+        _notify(
+            isCancelled
+                ? .failure(.speechSequenceCancelled(speeches))
+                : .success(.speechSequenceCompleted(speeches))
+        )
     }
     
     private func synthesize(_ speech: AimyboxSpeech) {
@@ -111,9 +115,9 @@ public class YandexTextToSpeech: AimyboxComponent, TextToSpeech {
         let synthesisGroup = DispatchGroup()
         
         synthesisGroup.enter()
-        synthesisAPI.request(text: textSpeech.text, language: languageCode, config: synthesisConfig) { [unowned self] url in
-            if let _wav_url = url {
-                self.synthesize(textSpeech, using: _wav_url)
+        synthesisAPI.request(text: textSpeech.text, language: languageCode, config: synthesisConfig) { [weak self] url in
+            if let _wav_url = url, self?.isCancelled == false {
+                self?.synthesize(textSpeech, using: _wav_url)
             }
             synthesisGroup.leave()
         }
@@ -141,26 +145,27 @@ public class YandexTextToSpeech: AimyboxComponent, TextToSpeech {
                 break
             }
         }
-
-        let didPlayToEndObservation = NotificationCenter.default.addObserver(forName: .AVPlayerItemDidPlayToEndTime,
-                                                                      object: player.currentItem,
-                                                                      queue: notificationQueue) { _ in
+        let stopObservation = player.observe(\.rate) { (player, _) in
+            guard player.rate == 0 else { return }
             _notify(.success(.speechEnded(speech)))
             synthesisGroup.leave()
         }
+
         let failedToPlayToEndObservation = NotificationCenter.default.addObserver(forName: .AVPlayerItemFailedToPlayToEndTime,
                                                                                   object: player.currentItem,
                                                                                   queue: notificationQueue) { _ in
             _notify(.failure(.emptySpeech(speech)))
             synthesisGroup.leave()
         }
-        
+
         synthesisGroup.enter()
-        player.play()
+        self.player = player
+        isCancelled ? synthesisGroup.leave() : player.play()
         synthesisGroup.wait()
-        
+
+        self.player = nil
+        stopObservation.invalidate()
         statusObservation?.invalidate()
-        NotificationCenter.default.removeObserver(didPlayToEndObservation)
         NotificationCenter.default.removeObserver(failedToPlayToEndObservation)
     }
     


### PR DESCRIPTION
There is a problem, when you call `YandexTextToSpeech` and an audio isn't playing, then application crashes. Also when you call `AVAudioPlayer.stop` the `.AVPlayerItemDidPlayToEndTime` notification isn't called and `YandexTextToSpeech` freezes.
That's why we decided to use `AVPlayer`, which is safer and more flexible.

In `AimyboxConcrete` I replaced setting speaking state to the `speechSequenceStarted` event, because there is a little delay between calling `Aimybox.speak` and `speechSequenceStarted`.

I added public init to YandexSynthesisConfig to be able to configure my own configuration with different voice etc.