### PR TITLE
Fix YandexSpeechToText crashes

### DIFF
--- a/Components/YandexSpeechKit/Sources/YandexRecognitionAPI/YandexRecognitionAPI.swift
+++ b/Components/YandexSpeechKit/Sources/YandexRecognitionAPI/YandexRecognitionAPI.swift
@@ -83,7 +83,9 @@ class YandexRecognitionAPI {
     }
 
     public func closeStream() {
-        stream = nil
+        try? stream?.closeSend { [weak self] in
+            self?.stream = nil
+        }
         client = nil
     }
 
@@ -92,7 +94,7 @@ class YandexRecognitionAPI {
         error handler: @escaping (Error)->(),
         stream: Yandex_Cloud_Ai_Stt_V2_SttServiceStreamingRecognizeCall?
     ) throws {
-        try stream?.receive { [weak self] result in
+        try stream?.receive { [weak self, weak stream] result in
             self?.operationQueue.addOperation {
                 switch result {
                 case .result(let object) where object != nil:

--- a/Components/YandexSpeechKit/Sources/YandexRecognitionAPI/YandexSpeechToText.swift
+++ b/Components/YandexSpeechKit/Sources/YandexRecognitionAPI/YandexSpeechToText.swift
@@ -117,7 +117,7 @@ public class YandexSpeechToText: AimyboxComponent, SpeechToText {
             let inputNode = audioEngine.inputNode
             let recordingFormat = audioFormat
             inputNode.removeTap(onBus: 0)
-            inputNode.installTap(onBus: 0, bufferSize: 1024, format: recordingFormat) { [stream] buffer, time in
+            inputNode.installTap(onBus: 0, bufferSize: 1024, format: recordingFormat) { [weak stream] buffer, time in
                 try? stream?.send(
                     Yandex_Cloud_Ai_Stt_V2_StreamingRecognitionRequest.with({ request in
                         guard let _bytes = buffer.int16ChannelData else { return }


### PR DESCRIPTION
[83b6a](https://github.com/just-ai/aimybox-ios-sdk/commit/83b6a2a4042aad02d791ecfb1431ade7ef3a643a) Фикс утечек памяти в YandexRecognitionAPI (проявились после обновления SwiftGRPC с 0.10.0 до 0.11.0)

[516fc09](https://github.com/just-ai/aimybox-ios-sdk/commit/516fc09e2f75f1e3e3fcf6e1bcc6333962387db1) Фикс краша, который происходил после вызова `stopRecognition` до того, как выполнился completion у `checkPermissions`

[1481b90](https://github.com/just-ai/aimybox-ios-sdk/commit/1481b9092a7e0dff1fb1d7999cf5d93c4423f555) Фикс краша, который возникал, когда `sampleRates` у `inputFormat` и `audioFormat` -- разные. Такое происходит на реальных девайсах, когда до начала слушания аудиосессия проигрывала звук/видео.